### PR TITLE
Spec helper fix

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,11 @@
 require 'simplecov'
 SimpleCov.start do
-  add_group 'Instagram', 'lib/Instagram'
+  add_group 'Instagram', 'lib/instagram'
   add_group 'Faraday Middleware', 'lib/faraday'
   add_group 'Specs', 'spec'
 end
 
-require File.expand_path('../../lib/Instagram', __FILE__)
+require File.expand_path('../../lib/instagram', __FILE__)
 
 require 'rspec'
 require 'webmock/rspec'


### PR DESCRIPTION
When running:

```
bundle exec rake spec
```

This error appeared:

```
/home/ndfine/code/instagram-ruby-gem/spec/spec_helper.rb:8:in `require': no such file to load -- home/ndfine/code/instagram-ruby-gem/lib/Instagram (LoadError)
```

So, here's a fix to some case-sensitive problem in spec/spec_helper
