### PR TITLE
OpenSSL instead of ruby-hmac gem

### DIFF
--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday_middleware', '~> 0.3.1')
   s.add_runtime_dependency('multi_json', '~> 0.0.5')
   s.add_runtime_dependency('hashie', '~> 1.0.0')
-  s.add_runtime_dependency('ruby-hmac', '~> 0.4.0')
   s.authors = ["Shayne Sweeney"]
   s.description = %q{A Ruby wrapper for the Instagram REST and Search APIs}
   s.post_install_message =<<eos

--- a/lib/instagram/client/subscriptions.rb
+++ b/lib/instagram/client/subscriptions.rb
@@ -1,4 +1,4 @@
-require 'hmac-sha1'
+require 'openssl'
 
 module Instagram
   class Client
@@ -127,7 +127,9 @@ module Instagram
           if !client_secret
             raise ArgumentError, "client_secret must be set during configure"
           end
-          verify_signature = HMAC::SHA1.hexdigest(client_secret, json)
+          hmac = OpenSSL::HMAC.new('sha1', Instagram.client_secret)
+          hmac.update(json)
+          verify_signature = hmac.hexdigest
 
           if options[:signature] != verify_signature
             raise Instagram::InvalidSignature, "invalid X-Hub-Signature does not match verify signature against client_secret"


### PR DESCRIPTION
According to Topfunky (https://github.com/topfunky/ruby-hmac), OpenSSL is 20x faster than the ruby-hmac gem and therefore you shouldn't use his gem.  I replaced ruby-hmac with openssl.

I kept having problems running the tests (check https://gist.github.com/909714), therefore I couldn't run the tests. You might want to run the tests before you pull this in. :)

Regards
Javier 

Signed-off-by: Javier Vazquez javier.vazquez@ringier.ch
