### PR TITLE
String.blank? is being used in error_body(body) but isn't included by default. Took at stab at fixing that for you.

### DIFF
--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday_middleware', '~> 0.3.1')
   s.add_runtime_dependency('multi_json', '~> 0.0.5')
   s.add_runtime_dependency('hashie', '~> 1.0.0')
+  s.add_runtime_dependency('active_support', '~> 3.0.7')
   s.authors = ["Shayne Sweeney"]
   s.description = %q{A Ruby wrapper for the Instagram REST and Search APIs}
   s.post_install_message =<<eos

--- a/lib/faraday/raise_http_4xx.rb
+++ b/lib/faraday/raise_http_4xx.rb
@@ -1,4 +1,5 @@
 require 'faraday'
+require 'active_support'
 
 # @private
 module Faraday


### PR DESCRIPTION
String.blank? is added by activesupport: 
http://as.rubyonrails.org/classes/Object.html#M000003

This function needed it:
def self.error_body(body)
