### PR TITLE
Adding support for /users/self/media/liked

### DIFF
--- a/lib/instagram/client/users.rb
+++ b/lib/instagram/client/users.rb
@@ -133,6 +133,21 @@ module Instagram
       response = get('users/self/feed', options)
       response["data"]
     end
+    
+    # Returns liked media items from the currently authorized user.
+    #
+    # @overload user_media_feed(options={})
+    #   @return [Array]
+    #   @example Return liked media images from user @shayne
+    #     Instagram.user_media_liked() # assuming @shayne is the authorized user
+    # @format :json
+    # @authenticated true
+    # @rate_limited true
+    # @see TODO:docs URL
+    def user_media_liked()
+      response = get('users/self/media/liked')
+      response["data"]
+    end
 
     # Returns a list of recent media items for a given user
     #


### PR DESCRIPTION
New endpoint for the Instagram API:

http://instagram.com/developer/endpoints/users/#get_users_liked_feed
