### PR TITLE
Key into the 'data' field of the user_liked_media response

### DIFF
--- a/lib/instagram/client/users.rb
+++ b/lib/instagram/client/users.rb
@@ -178,7 +178,7 @@ module Instagram
     # @rate_limited true
     def user_liked_media(options={})
       response = get("users/self/media/liked", options)
-      response
+      response["data"]
     end
 
     # Returns information about the current user's relationship (follow/following/etc) to another user


### PR DESCRIPTION
Was getting an error where it was looking at the data field in the response for users liked media
