### PR TITLE
Issue #17: fixed multi_json gem dependency conflict with Rails 3.1

### DIFF
--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bluecloth', '~> 2.0.11')
   s.add_runtime_dependency('faraday', '~> 0.5.4')
   s.add_runtime_dependency('faraday_middleware', '~> 0.3.1')
-  s.add_runtime_dependency('multi_json', '~> 0.0.5')
+  s.add_runtime_dependency('multi_json', '~> 1.0.3')
   s.add_runtime_dependency('hashie',  '>= 0.4.0')
   s.authors = ["Shayne Sweeney"]
   s.description = %q{A Ruby wrapper for the Instagram REST and Search APIs}


### PR DESCRIPTION
Since Rails 3.1 has been out for some time, I think it's a good idea to bring the Instagram gem up to date.

I updated the multi_json version in the gemspec, and confirmed that all tests pass.

Woud love to have this merged so I can return to using the officially supported gem! Thanks.
