### PR TITLE
Instagram.media_search takes two arguments, not one

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ API Usage Examples
     puts Instagram.follows
 
     # Get a list of media close to a given latitude and longitude
-    puts Instagram.media_search("37.7808851,-122.3948632")
+    puts Instagram.media_search("37.7808851","-122.3948632")
 
 	# Get a list of the overall most popular media items
 	puts Instagram.media_popular


### PR DESCRIPTION
Readme fix, Lat/Lng should be passed as 2 separate arguments, not a single string.
