### PR TITLE
Fixed missing 'query_values' method with version 0.8 of Faraday.

### DIFF
--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.4')
   s.add_development_dependency('webmock', '~> 1.6')
   s.add_development_dependency('bluecloth', '~> 2.0.11')
-  s.add_runtime_dependency('faraday', '~> 0.7')
+  s.add_runtime_dependency('faraday', '~> 0.8')
   s.add_runtime_dependency('faraday_middleware', '~> 0.8')
   s.add_runtime_dependency('multi_json', '~> 1.0.3')
   s.add_runtime_dependency('hashie',  '>= 0.4.0')

--- a/lib/faraday/oauth2.rb
+++ b/lib/faraday/oauth2.rb
@@ -7,13 +7,17 @@ module FaradayMiddleware
     def call(env)
 
       if env[:method] == :get or env[:method] == :delete
-        env[:url].query_values = {} if env[:url].query_values.nil?
+        if env[:url].query.nil?
+          query = {}
+        elsif
+          query = Faraday::Utils.parse_query(env[:url].query)
+        end
 
-        if @access_token and not env[:url].query_values["client_secret"]
-          env[:url].query_values = env[:url].query_values.merge(:access_token => @access_token)
+        if @access_token and not query["client_secret"]
+          env[:url].query = Faraday::Utils.build_query(query.merge(:access_token => @access_token))
           env[:request_headers] = env[:request_headers].merge('Authorization' => "Token token=\"#{@access_token}\"")
         elsif @client_id
-          env[:url].query_values = env[:url].query_values.merge(:client_id => @client_id)
+          env[:url].query = Faraday::Utils.build_query(query.merge(:client_id => @client_id))
         end
       else
         if @access_token and not env[:body] && env[:body][:client_secret]
@@ -24,8 +28,6 @@ module FaradayMiddleware
           env[:body] = env[:body].merge(:client_id => @client_id)
         end
       end
-
-      env[:url].query_values = nil if env[:url].query_values == {}
 
       @app.call env
     end


### PR DESCRIPTION
The env[:url] in OAuth2#call() is HTTP::URI class object with Faraday
version 0.8.
HTTP::URI class does not have 'query_values' method.
So, changed using 'query_values' to 'query'.
Notice: This modification can use over version 0.8 of Faraday.
For details of a change about env[:url], please visit the following.
https://github.com/technoweenie/faraday/commit/8f7f6694da1831403faa138ab826449cf504fd2a
