### PR TITLE
Update dependencies to make things Rails 3.recent friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ coverage/*
 doc/*
 log/*
 pkg/*
+.idea/*

--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -5,9 +5,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 2.4')
   s.add_development_dependency('webmock', '~> 1.6')
   s.add_development_dependency('bluecloth', '~> 2.0.11')
-  s.add_runtime_dependency('faraday', '~> 0.7')
+  s.add_runtime_dependency('faraday', '~> 0.8')
   s.add_runtime_dependency('faraday_middleware', '~> 0.8')
-  s.add_runtime_dependency('multi_json', '~> 1.0.3')
+  s.add_runtime_dependency('multi_json', '>= 1.0.3')
   s.add_runtime_dependency('hashie',  '>= 0.4.0')
   s.authors = ["Shayne Sweeney"]
   s.description = %q{A Ruby wrapper for the Instagram REST and Search APIs}


### PR DESCRIPTION
Update faraday and multi_json dependencies to a Rails 3.2-friendly state, edit oauth2 accordingly, add RubyMine's .idea/ to gitignore to make things friendlier.

I believe you've received separate pull requests for each of these, but this is of one piece, and the test harness is green.
