### PR TITLE
Allow better, faster multi_json until the 2.0 API break

### DIFF
--- a/instagram.gemspec
+++ b/instagram.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('bluecloth', '~> 2.0.11')
   s.add_runtime_dependency('faraday', '~> 0.7')
   s.add_runtime_dependency('faraday_middleware', '~> 0.8')
-  s.add_runtime_dependency('multi_json', '~> 1.0.3')
+  s.add_runtime_dependency('multi_json', '>= 1.0.3', '~> 1.0')
   s.add_runtime_dependency('hashie',  '>= 0.4.0')
   s.authors = ["Shayne Sweeney"]
   s.description = %q{A Ruby wrapper for the Instagram REST and Search APIs}


### PR DESCRIPTION
`multi_json` will break its API at 2.0; no need to cut off the 1.x updates that don't break API.
