### PR TITLE
Custom FaradayMiddleware OAuth2 class name to avoid conflict with other gems implementing FaradayMiddleware OAuth2.

### DIFF
--- a/lib/faraday/oauth2.rb
+++ b/lib/faraday/oauth2.rb
@@ -3,7 +3,7 @@ require 'faraday'
 # @private
 module FaradayMiddleware
   # @private
-  class OAuth2 < Faraday::Middleware
+  class InstagramOAuth2 < Faraday::Middleware
     def call(env)
 
       if env[:method] == :get or env[:method] == :delete

--- a/lib/instagram/connection.rb
+++ b/lib/instagram/connection.rb
@@ -15,7 +15,7 @@ module Instagram
       }
 
       Faraday::Connection.new(options) do |connection|
-        connection.use FaradayMiddleware::OAuth2, client_id, access_token
+        connection.use FaradayMiddleware::InstagramOAuth2, client_id, access_token
         connection.use Faraday::Request::UrlEncoded
         connection.use FaradayMiddleware::Mashify unless raw
         unless raw


### PR DESCRIPTION
I use this gem along with youtube_it, which both define FaradayMiddleware::OAuth2, thus overriding each other and conflicting.  This solution keeps the middleware in the Faraday namespace, but just defines a specific Instagram implementations.
