### PR TITLE
Add utility method for grabbing entire raw response

### DIFF
--- a/lib/instagram/client/utils.rb
+++ b/lib/instagram/client/utils.rb
@@ -2,6 +2,11 @@ module Instagram
   class Client
     # @private
     module Utils
+      def utils_raw_response
+        response = get('users/self/feed',nil,true)
+        response
+      end
+    
       private
 
       # Returns the configured user name or the user name of the authenticated user


### PR DESCRIPTION
I needed to access the values for 'X-Ratelimit-Limit' and 'X-Ratelimit-Remaining' Instagram provides in its headers (See [Issue #63](https://github.com/Instagram/instagram-ruby-gem/issues/63)), so I created a very simple utility method that grabs the entire API response (including headers) instead of just the body. 

Now I can get the values I need like this:

``` ruby
client = Instagram.client(:access_token => session[:access_token])
response = client.utils_raw_response
remaining = response.headers[:x_ratelimit_remaining]
limit = response.headers[:x_ratelimit_limit]
```
