### PR TITLE
Catches 502 and 504 errors.

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -13,8 +13,12 @@ module FaradayMiddleware
           raise Instagram::NotFound, error_message_400(response)
         when 500
           raise Instagram::InternalServerError, error_message_500(response, "Something is technically wrong.")
+        when 502
+          raise Instagram::BadGateway, error_message_500(response, "The server returned an invalid or incomplete response.")
         when 503
           raise Instagram::ServiceUnavailable, error_message_500(response, "Instagram is rate limiting your requests.")
+        when 504
+          raise Instagram::GatewayTimeout, error_message_500(response, "504 Gateway Time-out")
         end
       end
     end

--- a/lib/instagram/error.rb
+++ b/lib/instagram/error.rb
@@ -11,8 +11,14 @@ module Instagram
   # Raised when Instagram returns the HTTP status code 500
   class InternalServerError < Error; end
 
+  # Raised when Instagram returns the HTTP status code 502
+  class BadGateway < Error; end
+
   # Raised when Instagram returns the HTTP status code 503
   class ServiceUnavailable < Error; end
+
+  # Raised when Instagram returns the HTTP status code 504
+  class GatewayTimeout < Error; end
 
   # Raised when a subscription payload hash is invalid
   class InvalidSignature < Error; end

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -39,4 +39,34 @@ describe Faraday::Response do
       end.to raise_error(Instagram::BadRequest, /Bad words are bad./)
     end
   end
+
+  context 'when a 502 is raised with an HTML response' do
+    before do
+      stub_get('users/self/feed.json').to_return(
+        :body => '<html><body><h1>502 Bad Gateway</h1> The server returned an invalid or incomplete response. </body></html>',
+        :status => 502
+      )
+    end
+
+    it 'should raise an Instagram::BadGateway' do
+      lambda do
+        @client.user_media_feed()
+      end.should raise_error(Instagram::BadGateway)
+    end
+  end
+
+  context 'when a 504 is raised with an HTML response' do
+    before do
+      stub_get('users/self/feed.json').to_return(
+        :body => '<html> <head><title>504 Gateway Time-out</title></head> <body bgcolor="white"> <center><h1>504 Gateway Time-out</h1></center> <hr><center>nginx</center> </body> </html>',
+        :status => 504
+      )
+    end
+
+    it 'should raise an Instagram::GatewayTimeout' do
+      lambda do
+        @client.user_media_feed()
+      end.should raise_error(Instagram::GatewayTimeout)
+    end
+  end
 end


### PR DESCRIPTION
On occasion I have experienced `Faraday::Error::ParsingError` errors from the
gem because they are not caught in the HTTP Exception middleware. They then
fall through to the JSON parser, but since it is returning HTML from nginx
the parser throws an error instead.

I have added the extra errors and tests that include the HTML returned to
ensure that the middleware catches the errors before the JSON parser sees
them.
