### PR TITLE
make tag_recent_media return pagination

### DIFF
--- a/lib/instagram/client/tags.rb
+++ b/lib/instagram/client/tags.rb
@@ -34,7 +34,7 @@ module Instagram
       # @rate_limited true
       def tag_recent_media(id, *args)
         options = args.last.is_a?(Hash) ? args.pop : {}
-        response = get("tags/#{id}/media/recent", options)
+        response = get("tags/#{id}/media/recent", options, false, false, true)
         response
       end
 

--- a/spec/instagram/client/tags_spec.rb
+++ b/spec/instagram/client/tags_spec.rb
@@ -45,8 +45,8 @@ describe Instagram::Client do
 
         it "should return a list of media taken at a given location" do
           media = @client.tag_recent_media('cat')
-          media.should be_a Array
-          media.first.user.username.should == "amandavan"
+          media.data.should be_a Array
+          media.data.first.user.username.should == "amandavan"
         end
       end
 


### PR DESCRIPTION
fix #64

This changes the return value of the tag_recent_media to be consistent with the current api and allow pagination.

The downside is that you now need to use the data attributes to access the array of data.
