### PR TITLE
Improve the subscription process signature verification

### DIFF
--- a/lib/instagram/client/subscriptions.rb
+++ b/lib/instagram/client/subscriptions.rb
@@ -41,7 +41,7 @@ module Instagram
       #   @option options [String, Integer] :object_id When specifying a location or tag use the location's ID or tag name respectively
       #   @option options [String, Float] :lat The center latitude of an area, used when subscribing to a geography object
       #   @option options [String, Float] :lng The center longitude of an area, used when subscribing to a geography object
-      #   @option options [String, Integer] :radius The distance in meters you'd like to capture around a given point 
+      #   @option options [String, Integer] :radius The distance in meters you'd like to capture around a given point
       #
       #     Note that we only support "media" at this time, but we might support other types of subscriptions in the future.
       #   @return [Hashie::Mash] The subscription created.
@@ -124,7 +124,7 @@ module Instagram
       def process_subscription(json, options={}, &block)
         raise ArgumentError, "callbacks block expected" unless block_given?
 
-        if options[:signature]
+        if options.has_key?(:signature)
           if !client_secret
             raise ArgumentError, "client_secret must be set during configure"
           end

--- a/spec/instagram/client/subscriptions_spec.rb
+++ b/spec/instagram/client/subscriptions_spec.rb
@@ -136,11 +136,14 @@ describe Instagram::Client do
         end
 
         it "should raise an Instagram::InvalidSignature error" do
-          lambda do
-            @client.process_subscription(@json, :signature => "31337H4X0R") do |handler|
-              # hi
-            end
-          end.should raise_error(Instagram::InvalidSignature)
+          invalid_signatures = ["31337H4X0R", nil]
+          invalid_signatures.each do |signature|
+            lambda do
+              @client.process_subscription(@json, :signature => signature ) do |handler|
+                # hi
+              end
+            end.should raise_error(Instagram::InvalidSignature)
+          end
         end
       end
     end


### PR DESCRIPTION
``` ruby
Instagram.process_subscription(params[:body], signature: params["X-Hub-Signature"]) do |handler|
  # hi
end
```

With the above code, if a malicious request does not have a X-Hub-Signature header, the signature verification would be bypassed.
