### PR TITLE
Make global connection options configurable

### DIFF
--- a/lib/instagram/configuration.rb
+++ b/lib/instagram/configuration.rb
@@ -10,6 +10,7 @@ module Instagram
       :adapter,
       :client_id,
       :client_secret,
+      :connection_options,
       :endpoint,
       :format,
       :proxy,
@@ -30,6 +31,9 @@ module Instagram
 
     # By default, don't set an application secret
     DEFAULT_CLIENT_SECRET = nil
+
+    # By default, don't set any connection options
+    DEFAULT_CONNECTION_OPTIONS = {}
 
     # The endpoint that will be used to connect if none is set
     #
@@ -81,15 +85,16 @@ module Instagram
 
     # Reset all configuration options to defaults
     def reset
-      self.access_token   = DEFAULT_ACCESS_TOKEN
-      self.adapter        = DEFAULT_ADAPTER
-      self.client_id      = DEFAULT_CLIENT_ID
-      self.client_secret  = DEFAULT_CLIENT_SECRET
-      self.endpoint       = DEFAULT_ENDPOINT
-      self.format         = DEFAULT_FORMAT
-      self.proxy          = DEFAULT_PROXY
-      self.scope          = DEFAULT_SCOPE
-      self.user_agent     = DEFAULT_USER_AGENT
+      self.access_token       = DEFAULT_ACCESS_TOKEN
+      self.adapter            = DEFAULT_ADAPTER
+      self.client_id          = DEFAULT_CLIENT_ID
+      self.client_secret      = DEFAULT_CLIENT_SECRET
+      self.connection_options = DEFAULT_CONNECTION_OPTIONS
+      self.endpoint           = DEFAULT_ENDPOINT
+      self.format             = DEFAULT_FORMAT
+      self.proxy              = DEFAULT_PROXY
+      self.scope              = DEFAULT_SCOPE
+      self.user_agent         = DEFAULT_USER_AGENT
     end
   end
 end

--- a/lib/instagram/connection.rb
+++ b/lib/instagram/connection.rb
@@ -12,7 +12,7 @@ module Instagram
         :proxy => proxy,
         :ssl => {:verify => false},
         :url => endpoint,
-      }
+      }.merge(connection_options)
 
       Faraday::Connection.new(options) do |connection|
         connection.use FaradayMiddleware::InstagramOAuth2, client_id, access_token

--- a/spec/instagram/api_spec.rb
+++ b/spec/instagram/api_spec.rb
@@ -30,14 +30,15 @@ describe Instagram::API do
 
       before do
         @configuration = {
-          :client_id => 'CID',
-          :client_secret => 'CS',
-          :scope => 'comments relationships',
           :access_token => 'AT',
           :adapter => :typhoeus,
+          :client_id => 'CID',
+          :client_secret => 'CS',
+          :connection_options => { :ssl => { :verify => true } },
           :endpoint => 'http://tumblr.com/',
           :format => :xml,
           :proxy => 'http://shayne:sekret@proxy.example.com:8080',
+          :scope => 'comments relationships',
           :user_agent => 'Custom User Agent',
         }
       end
@@ -53,13 +54,24 @@ describe Instagram::API do
 
       context "after initilization" do
 
-        it "should override module configuration after initialization" do
-          api = Instagram::API.new
+        let(:api) { Instagram::API.new }
+
+        before do
           @configuration.each do |key, value|
             api.send("#{key}=", value)
           end
+        end
+
+        it "should override module configuration after initialization" do
           @keys.each do |key|
             api.send(key).should == @configuration[key]
+          end
+        end
+
+        describe "#connection" do
+          it "should use the connection_options" do
+            Faraday::Connection.should_receive(:new).with(include(:ssl => { :verify => true }))
+            api.send(:connection)
           end
         end
       end


### PR DESCRIPTION
An HTTP library agnostic connection_options hash strikes me as a better solution than duplicating all options provided by the HTTP lib within instagram (proxy, ssl, etc.). First, it decouples the instagram from the HTTP library. Second, it makes it easier for users to set more advanced configurations.

If this pull request is well received, I will send a similar one for request options. In particular, it would be useful to be able to set timeouts (which is done on the request level in Faraday).

Note that the first included commit is just some housekeeping that doesn't change any logic.
