### PR TITLE
Allow configuration of redirect uri in client

### DIFF
--- a/lib/instagram/configuration.rb
+++ b/lib/instagram/configuration.rb
@@ -10,6 +10,7 @@ module Instagram
       :client_id,
       :client_secret,
       :scope,
+      :redirect_uri,
       :access_token,
       :endpoint,
       :format,
@@ -85,6 +86,7 @@ module Instagram
       self.client_id      = DEFAULT_CLIENT_ID
       self.client_secret  = DEFAULT_CLIENT_SECRET
       self.scope          = DEFAULT_SCOPE
+      self.redirect_uri   = DEFAULT_REDIRECT_URI
       self.access_token   = DEFAULT_ACCESS_TOKEN
       self.endpoint       = DEFAULT_ENDPOINT
       self.format         = DEFAULT_FORMAT

--- a/lib/instagram/oauth.rb
+++ b/lib/instagram/oauth.rb
@@ -5,6 +5,7 @@ module Instagram
     def authorize_url(options={})
       options[:response_type] ||= "code"
       options[:scope] ||= scope if !scope.nil? && !scope.empty?
+      options[:redirect_uri] ||= self.redirect_uri
       params = authorization_params.merge(options)
       connection.build_url("/oauth/authorize/", params).to_s
     end
@@ -12,6 +13,7 @@ module Instagram
     # Return an access token from authorization
     def get_access_token(code, options={})
       options[:grant_type] ||= "authorization_code"
+      options[:redirect_uri] ||= self.redirect_uri
       params = access_token_params.merge(options)
       post("/oauth/access_token/", params.merge(:code => code), raw=false, unformatted=true, no_response_wrapper=true)
     end

--- a/spec/instagram/api_spec.rb
+++ b/spec/instagram/api_spec.rb
@@ -33,6 +33,7 @@ describe Instagram::API do
           :client_id => 'CID',
           :client_secret => 'CS',
           :scope => 'comments relationships',
+          :redirect_uri => 'http://http://localhost:4567/oauth/callback',
           :access_token => 'AT',
           :adapter => :typhoeus,
           :endpoint => 'http://tumblr.com/',
@@ -112,29 +113,76 @@ describe Instagram::API do
         url.should_not include("scope")
       end
     end
+
+    describe "redirect_uri" do
+      it "should fall back to configuration redirect_uri if not passed as option" do
+        redirect_uri = 'http://localhost:4567/oauth/callback'
+        params = { :redirect_uri => redirect_uri }
+        client = Instagram::Client.new(params)
+        url = client.authorize_url()
+        url.should =~ /redirect_uri=#{URI.escape(redirect_uri, Regexp.union('/',':'))}/
+      end
+
+      it "should override configuration redirect_uri if passed as option" do
+        redirect_uri_config = 'http://localhost:4567/oauth/callback_config'
+        params = { :redirect_uri => redirect_uri_config }
+        client = Instagram::Client.new(params)
+        redirect_uri_option = 'http://localhost:4567/oauth/callback_option'
+        options = { :redirect_uri => redirect_uri_option }
+        url = client.authorize_url(options)
+        url.should =~ /redirect_uri=#{URI.escape(redirect_uri_option, Regexp.union('/',':'))}/
+      end
+    end
   end
 
   describe ".get_access_token" do
 
-    before do
-      @client = Instagram::Client.new(:client_id => "CID", :client_secret => "CS")
-      @url = @client.send(:connection).build_url("/oauth/access_token/").to_s
-      stub_request(:post, @url).
-        with(:body => {:client_id => "CID", :client_secret => "CS", :redirect_uri => "http://localhost:4567/oauth/callback", :grant_type => "authorization_code", :code => "C"}).
-        to_return(:status => 200, :body => fixture("access_token.json"), :headers => {})
+    describe "common functionality" do
+      before do
+        @client = Instagram::Client.new(:client_id => "CID", :client_secret => "CS")
+        @url = @client.send(:connection).build_url("/oauth/access_token/").to_s
+        stub_request(:post, @url).
+          with(:body => {:client_id => "CID", :client_secret => "CS", :redirect_uri => "http://localhost:4567/oauth/callback", :grant_type => "authorization_code", :code => "C"}).
+          to_return(:status => 200, :body => fixture("access_token.json"), :headers => {})
+      end
+
+      it "should get the correct resource" do
+        @client.get_access_token(code="C", :redirect_uri => "http://localhost:4567/oauth/callback")
+        a_request(:post, @url).
+          with(:body => {:client_id => "CID", :client_secret => "CS", :redirect_uri => "http://localhost:4567/oauth/callback", :grant_type => "authorization_code", :code => "C"}).
+          should have_been_made
+      end
+
+      it "should return a hash with an access_token and user data" do
+        response = @client.get_access_token(code="C", :redirect_uri => "http://localhost:4567/oauth/callback")
+        response.access_token.should == "at"
+        response.user.username.should == "mikeyk"
+      end
     end
 
-    it "should get the correct resource" do
-      @client.get_access_token(code="C", :redirect_uri => "http://localhost:4567/oauth/callback")
-      a_request(:post, @url).
-        with(:body => {:client_id => "CID", :client_secret => "CS", :redirect_uri => "http://localhost:4567/oauth/callback", :grant_type => "authorization_code", :code => "C"}).
-        should have_been_made
-    end
+    describe "redirect_uri param" do
 
-    it "should return a hash with an access_token and user data" do
-      response = @client.get_access_token(code="C", :redirect_uri => "http://localhost:4567/oauth/callback")
-      response.access_token.should == "at"
-      response.user.username.should == "mikeyk"
+      before do
+        @redirect_uri_config = "http://localhost:4567/oauth/callback_config"
+        @client = Instagram::Client.new(:client_id => "CID", :client_secret => "CS", :redirect_uri => @redirect_uri_config)
+        @url = @client.send(:connection).build_url("/oauth/access_token/").to_s
+        stub_request(:post, @url)
+      end
+
+      it "should fall back to configuration redirect_uri if not passed as option" do
+        @client.get_access_token(code="C")
+        a_request(:post, @url).
+          with(:body => hash_including({:redirect_uri => @redirect_uri_config})).
+          should have_been_made
+      end
+
+      it "should override configuration redirect_uri if passed as option" do
+        redirect_uri_option = "http://localhost:4567/oauth/callback_option"
+        @client.get_access_token(code="C", :redirect_uri => redirect_uri_option)
+        a_request(:post, @url).
+          with(:body => hash_including({:redirect_uri => redirect_uri_option})).
+          should have_been_made
+      end
     end
   end
 end


### PR DESCRIPTION
A redirect uri can now be passed in the options in the configure method:

``` ruby
Instagram.configure do |config|
  config.client_id = 'CI'
  config.client_secret = 'CS'
  config.redirect_uri = 'http://localhost:3456/oauth/callback'
end 
```

This will be used as the default `redirect_uri`.  `authorize_url` and `get_access_token` no longer need to be passed a `:redirect_uri` option, however that option can still be passed to override the configured `redirect_uri` if one has been specified.  
