### PR TITLE
ignore .ruby-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 .bundle
 .rvmrc
+.ruby-version
 .yardoc
 .rake_tasks~
 Gemfile.lock


### PR DESCRIPTION
Git should ignore the .ruby-version file.  This file is used by multiple ruby version managers, and is the new recommended way to set the ruby version for rvm (replacing .rvmrc).
