### PR TITLE
Added methods to verify subscription signatures and challenges

### DIFF
--- a/lib/instagram/client/subscriptions.rb
+++ b/lib/instagram/client/subscriptions.rb
@@ -125,7 +125,7 @@ module Instagram
         end
       end
 
-      # Public: As a security measure, all updates from facebook are signed using
+      # Public: As a security measure, all updates from Instagram are signed using
       # X-Hub-Signature: sha1=XXXX where XXX is the sha1 of the json payload
       # using your application secret as the key.
       #


### PR DESCRIPTION
Currently you have to write the challenge method for verifying Subscriptions yourself.
Checking the "X-Hub-Signature" is also not possible outside of the process_subscription method.

This PR fixes that.
