### PR TITLE
Add no_response_wrapper as config option

### DIFF
--- a/lib/instagram/configuration.rb
+++ b/lib/instagram/configuration.rb
@@ -14,7 +14,8 @@ module Instagram
       :endpoint,
       :format,
       :user_agent,
-      :proxy
+      :proxy,
+      :no_response_wrapper
     ].freeze
 
     # An array of valid request/response formats
@@ -56,6 +57,9 @@ module Instagram
     # By default, don't use a proxy server
     DEFAULT_PROXY = nil
 
+    # By default, don't wrap responses with meta data (i.e. pagination)
+    DEFAULT_NO_RESPONSE_WRAPPER = false
+
     # The user agent that will be sent to the API endpoint if none is set
     DEFAULT_USER_AGENT = "Instagram Ruby Gem #{Instagram::VERSION}".freeze
 
@@ -81,15 +85,16 @@ module Instagram
 
     # Reset all configuration options to defaults
     def reset
-      self.adapter        = DEFAULT_ADAPTER
-      self.client_id      = DEFAULT_CLIENT_ID
-      self.client_secret  = DEFAULT_CLIENT_SECRET
-      self.scope          = DEFAULT_SCOPE
-      self.access_token   = DEFAULT_ACCESS_TOKEN
-      self.endpoint       = DEFAULT_ENDPOINT
-      self.format         = DEFAULT_FORMAT
-      self.user_agent     = DEFAULT_USER_AGENT
-      self.proxy          = DEFAULT_PROXY
+      self.adapter              = DEFAULT_ADAPTER
+      self.client_id            = DEFAULT_CLIENT_ID
+      self.client_secret        = DEFAULT_CLIENT_SECRET
+      self.scope                = DEFAULT_SCOPE
+      self.access_token         = DEFAULT_ACCESS_TOKEN
+      self.endpoint             = DEFAULT_ENDPOINT
+      self.format               = DEFAULT_FORMAT
+      self.user_agent           = DEFAULT_USER_AGENT
+      self.proxy                = DEFAULT_PROXY
+      self.no_response_wrapper  = DEFAULT_NO_RESPONSE_WRAPPER
     end
   end
 end

--- a/lib/instagram/request.rb
+++ b/lib/instagram/request.rb
@@ -2,22 +2,22 @@ module Instagram
   # Defines HTTP request methods
   module Request
     # Perform an HTTP GET request
-    def get(path, options={}, raw=false, unformatted=false, no_response_wrapper=false)
+    def get(path, options={}, raw=false, unformatted=false, no_response_wrapper=no_response_wrapper)
       request(:get, path, options, raw, unformatted, no_response_wrapper)
     end
 
     # Perform an HTTP POST request
-    def post(path, options={}, raw=false, unformatted=false, no_response_wrapper=false)
+    def post(path, options={}, raw=false, unformatted=false, no_response_wrapper=no_response_wrapper)
       request(:post, path, options, raw, unformatted, no_response_wrapper)
     end
 
     # Perform an HTTP PUT request
-    def put(path, options={}, raw=false, unformatted=false, no_response_wrapper=false)
+    def put(path, options={}, raw=false, unformatted=false, no_response_wrapper=no_response_wrapper)
       request(:put, path, options, raw, unformatted, no_response_wrapper)
     end
 
     # Perform an HTTP DELETE request
-    def delete(path, options={}, raw=false, unformatted=false, no_response_wrapper=false)
+    def delete(path, options={}, raw=false, unformatted=false, no_response_wrapper=no_response_wrapper)
       request(:delete, path, options, raw, unformatted, no_response_wrapper)
     end
 

--- a/spec/instagram/api_spec.rb
+++ b/spec/instagram/api_spec.rb
@@ -38,6 +38,7 @@ describe Instagram::API do
           :endpoint => 'http://tumblr.com/',
           :format => :xml,
           :proxy => 'http://shayne:sekret@proxy.example.com:8080',
+          :no_response_wrapper => true,
           :user_agent => 'Custom User Agent',
         }
       end


### PR DESCRIPTION
Add no_response_wrapper as a configuration option when instantiating a
client. Then all requests will use this as the default no_response_wrapper parameter. Useful if you
want to do pagination or use the other metadata that is not normally
sent back in responses.

For consistency, it may be advantageous to also add options for `raw` and `unformatted` to the client initiailizer. But in my case I just needed pagination options.
