### PR TITLE
Add error_type to error string if its not empty

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -44,7 +44,11 @@ module FaradayMiddleware
       if body.nil?
         nil
       elsif body['meta'] and body['meta']['error_message'] and not body['meta']['error_message'].empty?
-        ": #{body['meta']['error_message']}"
+        if not body['meta']['error_type'].empty?
+          ": #{body['meta']['error_message']} (#{body['meta']['error_type']})"
+        else
+          ": #{body['meta']['error_message']}"
+        end
       end
     end
 


### PR DESCRIPTION
Error type can be useful information, however it is never incorporated into the formatted error string.  Implementation/desired formatting are welcome to any desired change.  Just would like to see the error_type in the exception output.
