### PR TITLE
Add better error handling for 400 errors where Instagram's API does not ...

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -45,6 +45,8 @@ module FaradayMiddleware
         nil
       elsif body['meta'] and body['meta']['error_message'] and not body['meta']['error_message'].empty?
         ": #{body['meta']['error_message']}"
+      elsif body['error_message'] and not body['error_message'].empty?
+        ": #{body['error_type']}: #{body['error_message']}"
       end
     end
 

--- a/spec/faraday/response_spec.rb
+++ b/spec/faraday/response_spec.rb
@@ -36,7 +36,20 @@ describe Faraday::Response do
     it "should return the body error message" do
       expect do
         @client.user_media_feed()
-      end.to raise_error(Instagram::BadRequest, /Bad words are bad./)
+      end.to raise_error(Instagram::BadRequest, /Bad words are bad\./)
+    end
+  end
+
+  context "when a 400 is raised with no meta but an error_message" do
+    before do
+      stub_get('users/self/feed.json').
+        to_return(:body => '{"error_type": "OAuthException", "error_message": "No matching code found."}', :status => 400)
+    end
+
+    it "should return the body error type and message" do
+      expect do
+        @client.user_media_feed()
+      end.to raise_error(Instagram::BadRequest, /OAuthException: No matching code found\./)
     end
   end
 


### PR DESCRIPTION
...include errors in a meta property.

To solve problems reported in issue #22
