### PR TITLE
Change Instagram.respond_to? signature

### DIFF
--- a/lib/instagram.rb
+++ b/lib/instagram.rb
@@ -21,7 +21,7 @@ module Instagram
   end
 
   # Delegate to Instagram::Client
-  def self.respond_to?(method)
-    return client.respond_to?(method) || super
+  def self.respond_to?(method, include_all=false)
+    return client.respond_to?(method, include_all) || super
   end
 end


### PR DESCRIPTION
Ruby 1.9 and 2.0 allow `Object#respond_to?` to receive [two arguments](http://ruby-doc.org/core-2.1.2/Object.html#method-i-respond_to-3F):

``` ruby
respond_to?(symbol, include_all=false)
```

Current signature with only one argument makes trouble when using rspec 3.0 to mock `Instagram` class behavior.
