### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/instagram/client/subscriptions.rb
+++ b/lib/instagram/client/subscriptions.rb
@@ -183,7 +183,7 @@ module Instagram
           if !client_secret
             raise ArgumentError, "client_secret must be set during configure"
           end
-          digest = OpenSSL::Digest::Digest.new('sha1')
+          digest = OpenSSL::Digest.new('sha1')
           verify_signature = OpenSSL::HMAC.hexdigest(digest, client_secret, json)
 
           if options[:signature] != verify_signature

--- a/lib/instagram/request.rb
+++ b/lib/instagram/request.rb
@@ -51,7 +51,7 @@ module Instagram
     end
 
     def get_insta_fowarded_for(ips, secret)
-        digest = OpenSSL::Digest::Digest.new('sha256')
+        digest = OpenSSL::Digest.new('sha256')
         signature = OpenSSL::HMAC.hexdigest(digest, secret, ips)
         return [ips, signature].join('|')
     end

--- a/spec/instagram/request_spec.rb
+++ b/spec/instagram/request_spec.rb
@@ -5,7 +5,7 @@ describe Instagram::Request do
     before do
       @ips = "1.2.3.4"
       @secret = "CS"
-      digest = OpenSSL::Digest::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
       signature = OpenSSL::HMAC.hexdigest(digest, @secret, @ips)
       @signed_header = [@ips, signature].join('|')
     end


### PR DESCRIPTION
OpenSSL::Digest::Digest has been discouraged to use since Ruby 1.8 https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and was deprecated recently. ruby/ruby#446

This removes the deprecation warning shown in ruby 2.1 and above.
