### PR TITLE
return utils_raw_response to life

### DIFF
--- a/lib/instagram/client/utils.rb
+++ b/lib/instagram/client/utils.rb
@@ -11,7 +11,7 @@ module Instagram
       #   limit = response.headers[:x_ratelimit_limit]
       #
       def utils_raw_response
-        response = get('users/self/feed',nil,true)
+        response = get('users/self/feed',nil, false, true)
         response
       end
     

--- a/spec/instagram/client/utils_spec.rb
+++ b/spec/instagram/client/utils_spec.rb
@@ -1,0 +1,32 @@
+require File.expand_path('../../../spec_helper', __FILE__)
+
+describe Instagram::Client do
+  Instagram::Configuration::VALID_FORMATS.each do |format|
+    context ".new(:format => '#{format}')" do
+
+      before do
+        @client = Instagram::Client.new(:format => format, :client_id => 'CID', :client_secret => 'CS', :client_ips => '1.2.3.4', :access_token => 'AT')
+      end
+
+      describe '.utils_raw_response' do
+        before do
+          stub_get("users/self/feed.#{format}").
+              with(:query => {:access_token => @client.access_token}).
+              to_return(:body => fixture("user_media_feed.#{format}"), :headers => {:content_type => "application/#{format}; charset=utf-8"})
+        end
+
+        before(:each) do
+          @response = @client.utils_raw_response
+        end
+
+        it 'return raw data' do
+          expect(@response).to be_instance_of(Faraday::Response)
+        end
+
+        it 'response content headers' do
+          expect(@response).to be_respond_to(:headers)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
To get  raw response ref #125

Since `signature` parameter was added to request, method `utils_raw_respons` was broken
