### PR TITLE
Ratelimit support for responses from Instagram

### DIFF
--- a/lib/instagram/request.rb
+++ b/lib/instagram/request.rb
@@ -43,7 +43,8 @@ module Instagram
       end
       return response if raw
       return response.body if no_response_wrapper
-      return Response.create( response.body )
+      return Response.create( response.body, {:limit => response.headers['x-ratelimit-limit'].to_i,
+                                              :remaining => response.headers['x-ratelimit-remaining'].to_i} )
     end
 
     def formatted_path(path)

--- a/lib/instagram/response.rb
+++ b/lib/instagram/response.rb
@@ -1,16 +1,18 @@
 module Instagram
   module Response
-    def self.create( response_hash )
+    def self.create( response_hash, ratelimit_hash )
       data = response_hash.data.dup rescue response_hash
       data.extend( self )
       data.instance_exec do
         @pagination = response_hash.pagination
         @meta = response_hash.meta
+        @ratelimit = ::Hashie::Mash.new(ratelimit_hash)
       end
       data
     end
 
     attr_reader :pagination
     attr_reader :meta
+    attr_reader :ratelimit
   end
 end


### PR DESCRIPTION
- Include `x-ratelimit-remaining` and `x-ratelimit-limit` from the headers in the response.

The `utils_raw_response` unnecessarily uses an additional API call to fetch a raw response that includes the header where the limit can be checked.

This is not being limit-friendly when the other individual API requests include the header with this information but is filtered out by the Request/Response classes. That information should be included instead.
