### PR TITLE
Use OpenSSL::Digest.new instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/instagram/request.rb
+++ b/lib/instagram/request.rb
@@ -30,7 +30,7 @@ module Instagram
     def request(method, path, options, signature=false, raw=false, unformatted=false, no_response_wrapper=false, signed=sign_requests)
       response = connection(raw).send(method) do |request|
         path = formatted_path(path) unless unformatted
-        
+
         if signed == true
           if client_id != nil
             sig_options = options.merge({:client_id => client_id})
@@ -41,7 +41,7 @@ module Instagram
           sig = generate_sig("/"+path, sig_options, client_secret)
           options[:sig] = sig
         end
-        
+
         case method
         when :get, :delete
           request.url(URI.encode(path), options)
@@ -74,7 +74,7 @@ module Instagram
       params.sort.map do |key, val|
         sig += '|%s=%s' % [key, val]
       end
-      digest = OpenSSL::Digest::Digest.new('sha256')
+      digest = OpenSSL::Digest.new('sha256')
       return OpenSSL::HMAC.hexdigest(digest, secret, sig)
     end
 


### PR DESCRIPTION
It seems that one instance of the deprecated `OpenSSL::Digest::Digest` was missed when fixing https://github.com/Instagram/instagram-ruby-gem/pull/124

This should take care of the last of the OpenSSL deprecation warnings. 