### PR TITLE
Update locations.rb

### DIFF
--- a/lib/instagram/client/locations.rb
+++ b/lib/instagram/client/locations.rb
@@ -59,8 +59,8 @@ module Instagram
         options = args.last.is_a?(Hash) ? args.pop : {}
         case args.size
         when 1
-          foursquare_v2_id = args.first
-          response = get('locations/search', options.merge(:foursquare_v2_id => foursquare_v2_id))
+          facebook_places_id = args.first
+          response = get('locations/search', options.merge(:facebook_places_id => facebook_places_id))
         when 2
           lat, lng = args
           response = get('locations/search', options.merge(:lat => lat, :lng => lng))


### PR DESCRIPTION
foursquare_v2_id is deprecated by Instagram.  Please use facebook_places_id instead of foursquare_v2_id
