### PR TITLE
Add option to configure FaradayMiddleware::Mashify mash_class

### DIFF
--- a/lib/instagram/configuration.rb
+++ b/lib/instagram/configuration.rb
@@ -21,6 +21,7 @@ module Instagram
       :no_response_wrapper,
       :loud_logger,
       :sign_requests,
+      :mash_class
     ].freeze
 
     # By default, don't set a user access token
@@ -80,6 +81,8 @@ module Instagram
     # By default, requests are not signed
     DEFAULT_SIGN_REQUESTS = false
 
+    DEFAULT_MASH_CLASS = nil
+
     # @private
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -117,6 +120,7 @@ module Instagram
       self.no_response_wrapper= DEFAULT_NO_RESPONSE_WRAPPER
       self.loud_logger        = DEFAULT_LOUD_LOGGER
       self.sign_requests      = DEFAULT_SIGN_REQUESTS
+      self.mash_class         = DEFAULT_MASH_CLASS
     end
   end
 end

--- a/lib/instagram/connection.rb
+++ b/lib/instagram/connection.rb
@@ -16,6 +16,7 @@ module Instagram
       Faraday::Connection.new(options) do |connection|
         connection.use FaradayMiddleware::InstagramOAuth2, client_id, access_token
         connection.use Faraday::Request::UrlEncoded
+        FaradayMiddleware::Mashify.mash_class = Instagram.mash_class
         connection.use FaradayMiddleware::Mashify unless raw
         unless raw
           case format.to_s.downcase


### PR DESCRIPTION
I needed something like this in order to turn off this warning in the logs:

```
WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#count defined in Enumerable. This can cause unexpected behavior when accessing the key via as a property. You can still access the key via the #[] method.
```

I put this code in an initializer:
```
class InstaMash < ::Hashie::Mash
  disable_warnings
end

Instagram.configure do |config|
  config.mash_class = InstaMash
end
```