### PR TITLE
Add handling for missing signature with 'Enforce signed requests'

### DIFF
--- a/lib/instagram/error.rb
+++ b/lib/instagram/error.rb
@@ -28,4 +28,8 @@ module Instagram
 
   # Raised when Instagram returns the HTTP status code 429
   class RateLimitExceeded < Error; end
+
+  # Raised when Instagram app settings require signed requests
+  # and no 'sig' parameter present
+  class RequestNotSignedCorrectly < Error; end
 end

--- a/lib/instagram/response.rb
+++ b/lib/instagram/response.rb
@@ -1,6 +1,8 @@
 module Instagram
   module Response
     def self.create( response_hash, ratelimit_hash )
+      return if handle_potential_error(response_hash)
+
       data = response_hash.data.dup rescue response_hash
       data.extend( self )
       data.instance_exec do
@@ -12,6 +14,17 @@ module Instagram
         @ratelimit = ::Hashie::Mash.new(ratelimit_hash)
       end
       data
+    end
+
+    def self.handle_potential_error(response_hash)
+      err = begin
+        response_hash['error_type'] == 'OAuthForbiddenException'
+      rescue nil
+      end
+
+      if err
+        raise Instagram::RequestNotSignedCorrectly, response_hash['error_message']
+      end
     end
 
     attr_reader :pagination


### PR DESCRIPTION
**Context:** When the client is configured with the 'Enforce signed requests' checkbox signed. Calling `client.user` or any other API method.

**Without this PR:** raises `RuntimeError: can't modify frozen NilClass`

**With this PR:** raises `Instagram::RequestNotSignedCorrectly: Invalid signed-request: Missing required parameter 'sig'`