### PR TITLE
Ruby 2.4 Fix

### DIFF
--- a/lib/instagram/response.rb
+++ b/lib/instagram/response.rb
@@ -1,7 +1,7 @@
 module Instagram
   module Response
     def self.create( response_hash, ratelimit_hash )
-      data = response_hash.data.dup rescue response_hash
+      data = ::Hashie::Mash.new(response_hash.data) rescue response_hash
       data.extend( self )
       data.instance_exec do
         %w{pagination meta}.each do |k|


### PR DESCRIPTION
When response_hash.data is nil , instance_variable_set will throw error 'can't modify frozen NilClass' for Ruby > 2.2 , using the initialize of ::Hashie::Mash which duplicates the hash and does the necessary work.